### PR TITLE
fix biblatex error

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -2,7 +2,7 @@
 \geometry{left=25truemm,top=35truemm,right=25truemm,bottom=50truemm}
 
 \usepackage{subfiles}
-\usepackage[backend=biber]{biblatex}
+\usepackage[backend=biber,sorting=none]{biblatex}
 \addbibresource{main.bib}
 \input{packages}
 
@@ -58,7 +58,6 @@
 \addcontentsline{toc}{chapter}{\numberline{}参考文献}
 \renewcommand{\bibname}{参考文献}
 
-\bibliographystyle{junsrt}
 \printbibliography
 
 \subfile{appendix}


### PR DESCRIPTION
biblatexパッケージと\bibliographystyleを同時に使うと不可解なエラーが出ます。
junsrtと似たような挙動をしそうなsorting=noneにしてみました。